### PR TITLE
Use Java assertions to enforce critical assumptions in internal logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/duke_data.txt
+++ b/duke_data.txt
@@ -2,5 +2,5 @@
 2. [D][x] def (by: 123)
 3. [E][x] ghi (at: 456)
 4. [D][x] d (by: tmr)
-5. [D][ ] y (by: today)
+5. [D][x] y (by: today)
 6. [T][x] defg

--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -12,6 +12,7 @@ public class Duke {
      */
     public static void main(String[] args) {
 
+
         // Source : https://patorjk.com/software/taag/#p=display&f=Standard&t=Dude
         String logo2 = " ____            _      \n"
                 + "|  _ \\ _   _  __| | ___ \n"

--- a/src/main/java/duke/GUI.java
+++ b/src/main/java/duke/GUI.java
@@ -5,12 +5,6 @@ public class GUI {
     private DataFile dataFile;
     private TaskList taskList;
 
-    private final String WELCOME_MESSAGE = " ____            _      \n"
-            + "|  _ \\ _   _  __| | ___ \n"
-            + "| | | | | | |/ _` |/ _ \\\n"
-            + "| |_| | |_| | (_| |  __/\n"
-            + "|____/ \\__,_|\\__,_|\\___|\n";
-
     public static void main(String[] args) {
         Launcher.main(args);
     }
@@ -21,19 +15,18 @@ public class GUI {
     }
 
     public String getResponse(String s) {
-
         return processInput(s);
     }
 
     String processInput(String str) {
 
+        assert str != "";
         Task newTask = Parser.parseInput(str);
 
         if (newTask == null) {
             if (str.equals("bye")) {
                 taskList.save();
-                return "Bye. Hope to see you again soon!";
-
+                return "Tasklist saved; exiting not implemented yet!";
             } else if (str.equals("list")) {
                 return taskList.list();
             } else if (str.startsWith("done")) {
@@ -55,8 +48,5 @@ public class GUI {
         }
 
     }
-
-
-
     
 }

--- a/src/main/java/duke/Main.java
+++ b/src/main/java/duke/Main.java
@@ -23,6 +23,7 @@ public class Main extends Application {
             AnchorPane ap = fxmlLoader.load();
             Scene scene = new Scene(ap);
             stage.setScene(scene);
+            assert fxmlLoader.<MainWindow>getController() instanceof MainWindow;
             fxmlLoader.<MainWindow>getController().setGUI(gui);
             stage.show();
             fxmlLoader.<MainWindow>getController().welcome();

--- a/src/main/java/duke/Task.java
+++ b/src/main/java/duke/Task.java
@@ -31,6 +31,7 @@ abstract public class Task {
      * @return False if this task was previously marked as done, true otherwise.
      */
     public boolean markDone() {
+        assert !isDone;
         if (this.isDone) {
             return false;
         } else {

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -52,7 +52,7 @@ public class TaskList {
         if (isValid) {
             return "Nice! This task is marked as done\n" + t.toString();
         } else {
-            return "";
+            return "Already Done!" + t.toString();
         }
     }
     public String delete(int index) {


### PR DESCRIPTION
Printing error messages (removed from production code),
or using a boolean return value (used in Task.markDone()) was used,
which is inconvenient (deleting the print statements) and restrictive
(markDone() cannot be void or return some other type)

Java assertions were used to replace these "hacky" workarounds

This improves code flexibility and allows for more convenience, as the
assert statements can be left in the code and either enabled or disabled
at runtime